### PR TITLE
Fix issue for none option

### DIFF
--- a/src/Select_Field.php
+++ b/src/Select_Field.php
@@ -34,7 +34,7 @@ class Select_Field {
 			self::option([
 				'value' => $form['id'],
 				'label' => $form['title'],
-				'selected' => $selection === $form['id'],
+				'selected' => absint( $form['id'] ) === $selection,
 			]);
 		}
 	?>


### PR DESCRIPTION
There was an issue where the option was always false or the initial none as the value
was not reaching the correct comparision as the original value of the form was returned as string
from a call of the DB, but is rendered as an int on the usage of get_field.

With this change we make sure we are comparing always integer values.